### PR TITLE
Fix old volumes getting attached and upgrade to Python 3

### DIFF
--- a/ebs-pin
+++ b/ebs-pin
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 from ebspin import base, configuration
 import argparse, logging, sys
 

--- a/ebspin/base.py
+++ b/ebspin/base.py
@@ -1,5 +1,5 @@
 import boto3, logging, sys
-import ec2
+import ebspin.ec2 as ec2
 
 class Base:
     options = None

--- a/ebspin/ec2.py
+++ b/ebspin/ec2.py
@@ -1,5 +1,4 @@
 import time, logging, sys
-import aws_lambda_logging
 
 class Ec2:
     session = None

--- a/ebspin/ec2.py
+++ b/ebspin/ec2.py
@@ -113,7 +113,7 @@ class Ec2:
             tags = self.client.describe_volumes(VolumeIds=[volume_id])['Volumes'][0]['Tags']
 
             if extra_tags:
-                for key, value in extra_tags.iteritems():
+                for key, value in extra_tags.items():
                     tags.append({'Key':key, 'Value':value})
 
             self.tag_snapshot(snapshot_id, tags)
@@ -147,7 +147,7 @@ class Ec2:
             tags = [x for x in tags if x['Value'] is not None]
 
             # Add the tags provided from the command line
-            for key, value in options.tags.iteritems():
+            for key, value in options.tags.items():
                 tags.append({'Key':key, 'Value':value})
 
             return self.client.create_tags(

--- a/ebspin/ec2.py
+++ b/ebspin/ec2.py
@@ -15,8 +15,9 @@ class Ec2:
             ]
         try:
             volumes = self.client.describe_volumes(Filters=filters)['Volumes']
-            volumes = sorted(volumes, key=lambda ss:ss['CreateTime'])
-            volume = [x for x in volumes if x['State'] == 'available'].pop()
+            volumes = sorted(volumes, key=lambda ss:ss['CreateTime']).pop()
+            volume = volumes.pop()
+            print("Volume state is {}".format(volume['State']))
             return volume['VolumeId']
         except:
             return None

--- a/ebspin/ec2.py
+++ b/ebspin/ec2.py
@@ -1,4 +1,5 @@
 import time, logging, sys
+import aws_lambda_logging
 
 class Ec2:
     session = None
@@ -15,7 +16,7 @@ class Ec2:
             ]
         try:
             volumes = self.client.describe_volumes(Filters=filters)['Volumes']
-            volumes = sorted(volumes, key=lambda ss:ss['CreateTime']).pop()
+            volumes = sorted(volumes, key=lambda ss:ss['CreateTime'])
             volume = volumes.pop()
             print("Volume state is {}".format(volume['State']))
             return volume['VolumeId']


### PR DESCRIPTION
This PR fixes old volumes getting attached while the most recent one is in the process of detaching from the previous instance. It will now return an exception from boto3, which can be handled in your userdata. Might look at adding retry to this at some point.

It also upgrades to Python 3, fixing some minor compatibility issues.